### PR TITLE
Attachment rendering: Fix filtering of given groups

### DIFF
--- a/src/Maklermodul/FieldRenderer/Attachment.php
+++ b/src/Maklermodul/FieldRenderer/Attachment.php
@@ -20,6 +20,7 @@
 
 namespace Pdir\MaklermodulBundle\Maklermodul\FieldRenderer;
 
+use Contao\StringUtil;
 use Pdir\MaklermodulBundle\Maklermodul\FieldRenderer;
 use Pdir\MaklermodulBundle\Maklermodul\FieldTranslator;
 use Pdir\MaklermodulBundle\Util\Helper;
@@ -139,7 +140,8 @@ class Attachment extends FieldRenderer
     private function getShortString()
     {
         // show only given group
-        if (false !== strpos($this->getSetting('group'), $this->getValueOf('@gruppe'))) {
+        $givenGroups = StringUtil::trimsplit(',', $this->getSetting('group'));
+        if (empty($givenGroups) || \in_array($this->getValueOf('@gruppe'), $givenGroups)) {
             switch ($this->getValueOf('@gruppe')) {
                 case 'DOKUMENTE':
                     // render doc list


### PR DESCRIPTION
# Issue

If a group is provided to `Attachment::group()` that shares a part of its name with another group, the renderer will render all attachments of the latter group as well. For example, if you try to render only the group "TITELBILD", all images of the group "BILD" will also be rendered.

To reproduce this, you will need an OpenImmo XML file that contains references like this:
```
<anhaenge>
  <anhang ... gruppe="TITELBILD">
    ...
  </anhang>
  <anhang ... gruppe="BILD">
    ...
  </anhang>
  ...
</anhaenge>
```

Add the following in a `makler-details_simple` template:
```
<?php foreach ($this->estate->attachments()->range(0, null) as $attachment) : ?>
    <?php $attachment->group("TITELBILD")->render() ?>
<?php endforeach; ?>
```
This will render both "TITELBILD" and "BILD" attachments.

# Cause

In `Pdir\MaklermodulBundle\Maklermodul\FieldRenderer\Attachment::getShortString()`, `strpos` is used to check if the attachment's group matches any of the given comma-separated group names (or a single group name if only one is provided):
```
// show only given group
if (false !== strpos($this->getSetting('group'), $this->getValueOf('@gruppe')))
```
However, `strpos` is not useful here because it also finds the "BILD" part in "TITELBILD".

# Solution

We can split the comma-separated list using Contao's `StringUtil::trimsplit()` and then check if the resulting array is either empty (no group name set) or contains the group name.