### PR TITLE
Fix bug in filter translation

### DIFF
--- a/src/Module/ListView.php
+++ b/src/Module/ListView.php
@@ -333,10 +333,10 @@ class ListView extends Module
             foreach ($filter as $filterValueKey => $filterValue) {
                 $filterKey = str_replace('-', '.', $key);
 
-                $name = isset($GLOBALS['TL_LANG']['makler_modul_mplus']['field_keys'][$filterKey.'.@'.$filterValue['name']])?: null;
+                $name = $GLOBALS['TL_LANG']['makler_modul_mplus']['field_keys'][$filterKey.'.@'.$filterValue['name']] ?? null;
 
                 if (null === $name) {
-                    $name = isset($GLOBALS['TL_LANG']['makler_modul_mplus']['field_keys'][$filterKey . '.' . $filterValue['name']]) ?: null;
+                    $name = $GLOBALS['TL_LANG']['makler_modul_mplus']['field_keys'][$filterKey . '.' . $filterValue['name']] ?? null;
                 }
 
                 if (null !== $name) {


### PR DESCRIPTION
In the filter translation the name is set to a boolean instead of the translation value. 

It works for translations that are purely uppercase eg. ```KAUFEN``` because the value gets set again in Line ```348``` but does not for mixed eg. ```MIETE_PACHTEN```.

This bug can be fixed by using the ```Null Coalescing Operator```